### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     ],
     "description": "Tags and object classes can be customized",
     "docker_image": "supervisely/data-operations:6.73.564",
-    "instance_version": "6.4.57",
+    "instance_version": "6.15.60",
     "main_script": "src/main.py",
     "gui_template": "src/gui.html",
     "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
         "data operations"
     ],
     "description": "Tags and object classes can be customized",
-    "docker_image": "supervisely/data-operations:0.0.5",
+    "docker_image": "supervisely/data-operations:6.73.564",
     "instance_version": "6.4.57",
     "main_script": "src/main.py",
     "gui_template": "src/gui.html",

--- a/config.json
+++ b/config.json
@@ -1,24 +1,24 @@
 {
-    "name": "Copy image tags to objects",
-    "type": "app",
-    "categories": [
-        "images",
-        "annotation transformation",
-        "data operations"
-    ],
-    "description": "Tags and object classes can be customized",
-    "docker_image": "supervisely/data-operations:6.73.564",
-    "instance_version": "6.15.60",
-    "main_script": "src/main.py",
-    "gui_template": "src/gui.html",
-    "task_location": "workspace_tasks",
-    "icon": "https://i.imgur.com/bi0gqDJ.png",
-    "icon_background": "#FFFFFF",
-    "disable_stop": true,
-    "context_menu": {
-        "target": [
-            "images_project"
-        ]
-    },
-    "poster": "https://user-images.githubusercontent.com/106374579/183398752-8e83aaef-607c-4755-baa1-749f6c617d49.png"
+  "name": "Copy image tags to objects",
+  "type": "app",
+  "categories": [
+    "images",
+    "annotation transformation",
+    "data operations"
+  ],
+  "description": "Tags and object classes can be customized",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "main_script": "src/main.py",
+  "gui_template": "src/gui.html",
+  "task_location": "workspace_tasks",
+  "icon": "https://i.imgur.com/bi0gqDJ.png",
+  "icon_background": "#FFFFFF",
+  "disable_stop": true,
+  "context_menu": {
+    "target": [
+      "images_project"
+    ]
+  },
+  "poster": "https://user-images.githubusercontent.com/106374579/183398752-8e83aaef-607c-4755-baa1-749f6c617d49.png"
 }

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "data operations"
   ],
   "description": "Tags and object classes can be customized",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.70
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
